### PR TITLE
Do not update id on fetch (fixes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ vim ~/.config/ovh-redirections.yaml
 
 ### Fetch
 
-Fetch redirections list with details, sort and group them then write them to a file.
+Fetch redirections list with details, sort and group them then write them to an
+hidden file `.example.com_ovh-redirections.yaml`. *This file should not be
+edited*
 
 ```
 ./ovh-redirections fetch
 ```
 
-*This file should not be edited*
-
 ### Checkout
 
-Copy previously fetched redirections file to a editable file named *example.com_ovh-redirections.yaml*
+Copy previously fetched redirections file to a editable file named
+`example.com_ovh-redirections.yaml`.
 
 ```
 ./ovh-redirections checkout

--- a/ovh-redirections
+++ b/ovh-redirections
@@ -68,18 +68,28 @@ def fetch():
         redirections.append(redirection)
 
     redirections_dict = _group_redirections(redirections)
-    f_r = open(remote_db, 'w')
-    yaml.dump(redirections_dict, f_r, indent=2, default_flow_style=False)
+
+    with open(remote_db, 'w') as f_r:
+        yaml.dump(redirections_dict, f_r, indent=2, default_flow_style=False)
+
     print('Redirections written to "{}"'.format(remote_db))
-    _update_local_ids()
+
+    # Try to update local IDs if the local database exists
+    if os.path.isfile(local_db):
+        _update_local_ids()
 
 def _update_local_ids():
     f_l = _open_local_db()
+
+    # Local redirections
     l_redirections_dict = yaml.load(f_l)
     l_redirections = _flat_redirections(l_redirections_dict)
+
+    # Remote redirections
     f_r = open(remote_db, 'r')
     r_redirections = _flat_redirections(yaml.load(f_r))
 
+    # Compute differences between local and remote redirections
     r_l = set(r_redirections) - set(l_redirections)
     l_r = set(l_redirections) - set(r_redirections)
 


### PR DESCRIPTION
The `_update_local_ids()` function will try to update the `mydomain.org_ovh-redirections.yaml` file (with no dot) but the fetch function will create the `.mydomain.org_ovh-redirections.yaml` (with a dot) so thats why there is an error.

Wait for checkout in order to update local ids should be enough.