### PR TITLE
Indicate where to create the virtual env

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd ovh-redirections
 ```
 
 ```
-python3 -m venv
+python3 -m venv . 
 source bin/activate
 pip install ovh pyyaml
 ```


### PR DESCRIPTION
Indicate where to create the virtual env, I get an error with current command that do no precise path where to create virtual env.
From the latter description I guess, path should be current path, so adding '.' in command: python3 -m venv .